### PR TITLE
Fix migration file V145 relate to default value of DATE type field

### DIFF
--- a/fineract-provider/src/main/resources/sql/migrations/core_db/V145__add_force_password_reset_in_c_configuration.sql
+++ b/fineract-provider/src/main/resources/sql/migrations/core_db/V145__add_force_password_reset_in_c_configuration.sql
@@ -19,10 +19,8 @@
 
 INSERT INTO `c_configuration` (`id`, `name`, `value`, `enabled`) VALUES (NULL, 'force-password-reset-days', '0', '0');
 
-ALTER TABLE  `m_appuser` ADD  `last_time_password_updated` DATE NOT NULL ,
+ALTER TABLE  `m_appuser` ADD  `last_time_password_updated` DATE DEFAULT '1000-01-01' NOT NULL ,
 ADD INDEX (  `last_time_password_updated` ) ;
-
-UPDATE  `m_appuser` SET  `last_time_password_updated` =  NOW() WHERE  `m_appuser`.`last_time_password_updated` ='0000-00-00';
 
 CREATE TABLE IF NOT EXISTS `m_appuser_previous_password` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Issue is occuring in mysql 5.7

As per latest MYSQL 5.7 [documentation](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict)
If strict mode is enabled, '0000-00-00' is not permitted and produce an error


