### PR TITLE
FINERACT-2173: Implement migration completed listener in custom module

### DIFF
--- a/custom/migration/loan/impl/build.gradle
+++ b/custom/migration/loan/impl/build.gradle
@@ -18,12 +18,11 @@
  */
 description = 'Custom loan migration'
 
-group = 'custom.migration.loan'
+group = 'custom.fineract.migration.loan'
 
 base {
     archivesName = 'custom-fineract-migration-loan'
 }
 
-apply from: 'dependencies.gradle'
-
 apply plugin: 'java-library'
+apply from: 'dependencies.gradle'

--- a/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/configuration/LoanMigrationConfiguration.java
+++ b/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/configuration/LoanMigrationConfiguration.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package custom.fineract.migration.loan.configuration;
+
+import custom.fineract.migration.loan.service.MigrationCompletedListener;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.event.business.domain.datatable.DatatableEntryCreatedBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class LoanMigrationConfiguration {
+
+    private final BusinessEventNotifierService businessEventNotifierService;
+    private final MigrationCompletedListener migrationCompletedListener;
+
+    @PostConstruct
+    public void addListeners() {
+        businessEventNotifierService.addPostBusinessEventListener(DatatableEntryCreatedBusinessEvent.class, migrationCompletedListener);
+    }
+
+}

--- a/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/constants/DtMigrationNames.java
+++ b/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/constants/DtMigrationNames.java
@@ -16,17 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package custom.fineract.migration.loan.constants;
 
-dependencies {
-    implementation(project(':fineract-core'))
-    implementation(project(':fineract-loan'))
-    implementation(project(':fineract-provider'))
-    implementation('com.google.code.gson:gson')
-    implementation('org.springframework.boot:spring-boot-starter')
-    implementation('org.springframework.boot:spring-boot-starter-data-jpa')
-    implementation('org.projectlombok:lombok')
-    annotationProcessor('org.projectlombok:lombok')
-    implementation('org.eclipse.persistence:org.eclipse.persistence.jpa') {
-        exclude group: 'org.eclipse.persistence', module: 'jakarta.persistence'
-    }
+public final class DtMigrationNames {
+
+    private DtMigrationNames() {}
+
+    public static final String DATATABLE_NAME = "dt_migration";
+    public static final String STATUS_COLUMN = "status";
+
 }

--- a/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/service/CustomExternalBusinessEventConfigurationServiceImpl.java
+++ b/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/service/CustomExternalBusinessEventConfigurationServiceImpl.java
@@ -18,6 +18,9 @@
  */
 package custom.fineract.migration.loan.service;
 
+import static custom.fineract.migration.loan.constants.DtMigrationNames.STATUS_COLUMN;
+
+import custom.fineract.migration.loan.constants.DtMigrationNames;
 import custom.fineract.migration.loan.enums.MigrationStatus;
 import java.util.List;
 import java.util.Objects;
@@ -62,23 +65,24 @@ public class CustomExternalBusinessEventConfigurationServiceImpl implements Exte
 
     private boolean doesDtMigrationTableExist() {
         try {
-            return readWriteNonCoreDataService.retrieveDatatable("dt_migration") != null;
+            return readWriteNonCoreDataService.retrieveDatatable(DtMigrationNames.DATATABLE_NAME) != null;
         } catch (Exception e) {
             return false;
         }
     }
 
     private List<MigrationStatus> getMigrationStatuses() {
-        return readWriteNonCoreDataService.queryDataTable("dt_migration", "status", null, "status").stream().map(jsonObject -> {
-            if (jsonObject.has("status")) {
-                try {
-                    return MigrationStatus.valueOf(jsonObject.get("status").getAsString());
-                } catch (IllegalArgumentException e) {
+        return readWriteNonCoreDataService.queryDataTable(DtMigrationNames.DATATABLE_NAME, STATUS_COLUMN, null, STATUS_COLUMN).stream()
+                .map(jsonObject -> {
+                    if (jsonObject.has(STATUS_COLUMN)) {
+                        try {
+                            return MigrationStatus.valueOf(jsonObject.get(STATUS_COLUMN).getAsString());
+                        } catch (IllegalArgumentException e) {
+                            return null;
+                        }
+                    }
                     return null;
-                }
-            }
-            return null;
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+                }).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
 }

--- a/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/service/MigrationCompletedListener.java
+++ b/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/service/MigrationCompletedListener.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package custom.fineract.migration.loan.service;
+
+import custom.fineract.migration.loan.constants.DtMigrationNames;
+import custom.fineract.migration.loan.enums.MigrationStatus;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.infrastructure.event.business.BusinessEventListener;
+import org.apache.fineract.infrastructure.event.business.domain.datatable.DatatableEntryCreatedBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.domain.loan.LoanAccountSnapshotBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MigrationCompletedListener implements BusinessEventListener<DatatableEntryCreatedBusinessEvent> {
+
+    private final BusinessEventNotifierService businessEventNotifierService;
+    private final LoanRepository loanRepository;
+
+    @Override
+    public void onBusinessEvent(final DatatableEntryCreatedBusinessEvent event) {
+        if (!DtMigrationNames.DATATABLE_NAME.equals(event.getDatatableEntryDetails().getDatatableName())) {
+            return;
+        }
+
+        final String status = (String) event.getDatatableEntryDetails().getData().get(DtMigrationNames.STATUS_COLUMN);
+        if (status == null || !MigrationStatus.MIGRATION_COMPLETED.toString().equals(status)) {
+            return;
+        }
+
+        final Long loanId = event.getDatatableEntryDetails().getEntityId();
+
+        loanRepository.findById(loanId)
+                .ifPresent(loan -> businessEventNotifierService.notifyPostBusinessEvent(new LoanAccountSnapshotBusinessEvent(loan)));
+    }
+
+}

--- a/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/service/MigrationServiceImpl.java
+++ b/custom/migration/loan/impl/src/main/java/custom/fineract/migration/loan/service/MigrationServiceImpl.java
@@ -18,6 +18,9 @@
  */
 package custom.fineract.migration.loan.service;
 
+import static custom.fineract.migration.loan.constants.DtMigrationNames.STATUS_COLUMN;
+
+import custom.fineract.migration.loan.constants.DtMigrationNames;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -35,13 +38,13 @@ public class MigrationServiceImpl implements MigrationService {
 
     @Override
     public Optional<String> findLastStatus(final Long loanId) {
-        final GenericResultsetData resultSet = readWriteNonCoreDataService.retrieveDataTableGenericResultSet("dt_migration", loanId,
-                "id desc", null);
+        final GenericResultsetData resultSet = readWriteNonCoreDataService
+                .retrieveDataTableGenericResultSet(DtMigrationNames.DATATABLE_NAME, loanId, "id desc", null);
         if (resultSet != null && !resultSet.getData().isEmpty()) {
             final Map<String, Integer> columnMap = IntStream.range(0, resultSet.getColumnHeaders().size()).boxed()
                     .collect(Collectors.toMap(i -> resultSet.getColumnHeaders().get(i).getColumnName(), i -> i));
 
-            final Object status = resultSet.getData().get(0).getRow().get(columnMap.get("status"));
+            final Object status = resultSet.getData().get(0).getRow().get(columnMap.get(STATUS_COLUMN));
             return Optional.ofNullable((String) status);
         }
 

--- a/custom/migration/loan/impl/src/test/java/custom/fineract/migration/loan/service/MigrationCompletedListenerTest.java
+++ b/custom/migration/loan/impl/src/test/java/custom/fineract/migration/loan/service/MigrationCompletedListenerTest.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package custom.fineract.migration.loan.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import custom.fineract.migration.loan.constants.DtMigrationNames;
+import custom.fineract.migration.loan.enums.MigrationStatus;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.fineract.infrastructure.dataqueries.data.EntityTables;
+import org.apache.fineract.infrastructure.event.business.domain.datatable.DatatableEntryCreatedBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.domain.datatable.DatatableEntryDetails;
+import org.apache.fineract.infrastructure.event.business.domain.loan.LoanAccountSnapshotBusinessEvent;
+import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MigrationCompletedListenerTest {
+
+    @Mock
+    private BusinessEventNotifierService businessEventNotifierService;
+
+    @Mock
+    private LoanRepository loanRepository;
+
+    @Mock
+    private DatatableEntryCreatedBusinessEvent event;
+
+    @Mock
+    private Loan loan;
+
+    private MigrationCompletedListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new MigrationCompletedListener(businessEventNotifierService, loanRepository);
+    }
+
+    @Test
+    void shouldProcessEventWhenMigrationIsCompleted() {
+        final Long loanId = 1L;
+        final Map<String, Object> data = new HashMap<>();
+        data.put(DtMigrationNames.STATUS_COLUMN, MigrationStatus.MIGRATION_COMPLETED.toString());
+
+        when(event.getDatatableEntryDetails()).thenReturn(mockDatatableEntryDetails(DtMigrationNames.DATATABLE_NAME, loanId, data));
+        when(loanRepository.findById(loanId)).thenReturn(Optional.of(loan));
+
+        listener.onBusinessEvent(event);
+
+        final ArgumentCaptor<LoanAccountSnapshotBusinessEvent> eventCaptor = ArgumentCaptor
+                .forClass(LoanAccountSnapshotBusinessEvent.class);
+        verify(businessEventNotifierService).notifyPostBusinessEvent(eventCaptor.capture());
+
+        assertThat(eventCaptor.getValue().get()).isEqualTo(loan);
+    }
+
+    @Test
+    void shouldNotProcessEventWhenDatatableNameIsDifferent() {
+        when(event.getDatatableEntryDetails()).thenReturn(mockDatatableEntryDetails("different_table", 1L, new HashMap<>()));
+
+        listener.onBusinessEvent(event);
+
+        verifyNoInteractions(loanRepository, businessEventNotifierService);
+    }
+
+    @Test
+    void shouldNotProcessEventWhenStatusIsNotCompleted() {
+        final Map<String, Object> data = new HashMap<>();
+        data.put(DtMigrationNames.STATUS_COLUMN, "IN_PROGRESS");
+
+        when(event.getDatatableEntryDetails()).thenReturn(mockDatatableEntryDetails(DtMigrationNames.DATATABLE_NAME, 1L, data));
+
+        listener.onBusinessEvent(event);
+
+        verifyNoInteractions(loanRepository, businessEventNotifierService);
+    }
+
+    @Test
+    void shouldNotProcessEventWhenStatusIsNull() {
+        final Map<String, Object> data = new HashMap<>();
+        data.put(DtMigrationNames.STATUS_COLUMN, null);
+
+        when(event.getDatatableEntryDetails()).thenReturn(mockDatatableEntryDetails(DtMigrationNames.DATATABLE_NAME, 1L, data));
+
+        listener.onBusinessEvent(event);
+
+        verifyNoInteractions(loanRepository, businessEventNotifierService);
+    }
+
+    @Test
+    void shouldNotProcessEventWhenLoanNotFound() {
+        final Long loanId = 1L;
+        final Map<String, Object> data = new HashMap<>();
+        data.put(DtMigrationNames.STATUS_COLUMN, MigrationStatus.MIGRATION_COMPLETED.toString());
+
+        when(event.getDatatableEntryDetails()).thenReturn(mockDatatableEntryDetails(DtMigrationNames.DATATABLE_NAME, loanId, data));
+        when(loanRepository.findById(loanId)).thenReturn(Optional.empty());
+
+        listener.onBusinessEvent(event);
+
+        verifyNoInteractions(businessEventNotifierService);
+    }
+
+    private DatatableEntryDetails mockDatatableEntryDetails(final String datatableName, final Long entityId,
+            final Map<String, Object> data) {
+        return new DatatableEntryDetails(datatableName, EntityTables.LOAN, entityId, entityId, data);
+    }
+
+}


### PR DESCRIPTION
## Description

Implement a istener that listens for DatatableEntryCreatedBusinessEvent and if new entry was created for the “dt_migration” table with value of “MIGRATION_COMPLETED” then we should trigger a LoanAccountSnapshotBusinessEvent

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
