### PR TITLE
FINERACT-2350: Fix DockerHub tags, use 'latest' for develop and version tags for release

### DIFF
--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -41,7 +41,7 @@ jobs:
           else
             TAGS="${{ github.ref_name }}"
           fi
-          
+
           ./gradlew --no-daemon --console=plain :fineract-provider:jib -x test -x cucumber \
             -Djib.to.auth.username=${{secrets.DOCKERHUB_USER}} \
             -Djib.to.auth.password=${{secrets.DOCKERHUB_TOKEN}} \

--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -36,10 +36,12 @@ jobs:
 
       - name: Build the Apache Fineract image
         run:  |
-          TAGS=${{ github.ref_name }}
           if [ "${{ github.ref_name }}" == "develop" ]; then
-            TAGS="$TAGS,${{ steps.git_hashes.outputs.short_hash }},${{ steps.git_hashes.outputs.long_hash }}"
+            TAGS="latest"
+          else
+            TAGS="${{ github.ref_name }}"
           fi
+          
           ./gradlew --no-daemon --console=plain :fineract-provider:jib -x test -x cucumber \
             -Djib.to.auth.username=${{secrets.DOCKERHUB_USER}} \
             -Djib.to.auth.password=${{secrets.DOCKERHUB_TOKEN}} \


### PR DESCRIPTION
…eases

## Description

This PR updates the DockerHub publishing workflow (`publish-dockerhub.yml`) to improve tag naming:

- For builds from the `develop` branch → publish image with the `latest` tag.  
- For builds from release tags (`1.*`) → publish image with the version number only.  
- Removes publishing of commit hashes and the `develop` tag.  

This change makes the "Recent tags" dropdown on DockerHub more understandable for end users.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests  
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.  
- [ ] Create/update unit or integration tests for verifying the changes made. *(Not applicable — workflow change only)*  
- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.  
- [ ] Add required Swagger annotation and update API documentation at `fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm` with details of any API changes. *(Not applicable — no API change)*  
- [x] Submission is not a "code dump".  
