### PR TITLE
FINERACT-2522: Fix max disbursement amount validation for multidisbur…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanDisbursementValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanDisbursementValidator.java
@@ -34,8 +34,7 @@ public final class LoanDisbursementValidator {
 
     private final LoanApplicationValidator loanApplicationValidator;
 
-    public void compareDisbursedToApprovedOrProposedPrincipal(final Loan loan, final BigDecimal disbursedAmount,
-            final BigDecimal totalDisbursed) {
+    public void compareDisbursedToApprovedOrProposedPrincipal(final Loan loan, final BigDecimal disbursedAmount,final BigDecimal totalDisbursed) {
         final BigDecimal totalCapitalizedIncome = loan.getSummary().getTotalCapitalizedIncome();
         final BigDecimal totalCapitalizedIncomeAdjustment = MathUtil.nullToZero(loan.getSummary().getTotalCapitalizedIncomeAdjustment());
         final BigDecimal netCapitalizedIncome = totalCapitalizedIncome.subtract(totalCapitalizedIncomeAdjustment);
@@ -44,7 +43,7 @@ public final class LoanDisbursementValidator {
             validateOverMaximumAmount(loan, totalDisbursed, netCapitalizedIncome);
         } else {
             if (loan.loanProduct().isAllowApprovedDisbursedAmountsOverApplied()) {
-                validateOverMaximumAmount(loan, disbursedAmount, netCapitalizedIncome);
+                validateOverMaximumAmount(loan, totalDisbursed, netCapitalizedIncome);
             } else {
                 if ((totalDisbursed.compareTo(loan.getApprovedPrincipal()) > 0)
                         || (totalDisbursed.add(netCapitalizedIncome).compareTo(loan.getApprovedPrincipal()) > 0)) {
@@ -55,6 +54,7 @@ public final class LoanDisbursementValidator {
             }
         }
     }
+
 
     public void validateOverMaximumAmount(final Loan loan, final BigDecimal totalDisbursed, final BigDecimal capitalizedIncome) {
         final BigDecimal maxDisbursedAmount = loanApplicationValidator.getOverAppliedMax(loan);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanDisbursementValidator.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanDisbursementValidator.java
@@ -34,7 +34,8 @@ public final class LoanDisbursementValidator {
 
     private final LoanApplicationValidator loanApplicationValidator;
 
-    public void compareDisbursedToApprovedOrProposedPrincipal(final Loan loan, final BigDecimal disbursedAmount,final BigDecimal totalDisbursed) {
+    public void compareDisbursedToApprovedOrProposedPrincipal(final Loan loan, final BigDecimal disbursedAmount,
+            final BigDecimal totalDisbursed) {
         final BigDecimal totalCapitalizedIncome = loan.getSummary().getTotalCapitalizedIncome();
         final BigDecimal totalCapitalizedIncomeAdjustment = MathUtil.nullToZero(loan.getSummary().getTotalCapitalizedIncomeAdjustment());
         final BigDecimal netCapitalizedIncome = totalCapitalizedIncome.subtract(totalCapitalizedIncomeAdjustment);
@@ -54,7 +55,6 @@ public final class LoanDisbursementValidator {
             }
         }
     }
-
 
     public void validateOverMaximumAmount(final Loan loan, final BigDecimal totalDisbursed, final BigDecimal capitalizedIncome) {
         final BigDecimal maxDisbursedAmount = loanApplicationValidator.getOverAppliedMax(loan);

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidatorImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/serialization/LoanTransactionValidatorImpl.java
@@ -162,8 +162,9 @@ public class LoanTransactionValidatorImpl implements LoanTransactionValidator {
             validateLoanClientIsActive(loan);
             validateLoanGroupIsActive(loan);
 
-            final BigDecimal disbursedAmount = loan.getSummary().getTotalPrincipalDisbursed();
-            loanDisbursementValidator.compareDisbursedToApprovedOrProposedPrincipal(loan, principal, disbursedAmount);
+            final BigDecimal alreadyDisbursed = loan.getSummary().getTotalPrincipalDisbursed();
+            final BigDecimal totalDisbursedIncludingCurrent = alreadyDisbursed.add(principal != null ? principal : BigDecimal.ZERO);
+            loanDisbursementValidator.compareDisbursedToApprovedOrProposedPrincipal(loan, principal, totalDisbursedIncludingCurrent);
 
             if (loan.isChargedOff()) {
                 throw new GeneralPlatformDomainRuleException("error.msg.loan.disbursal.not.allowed.on.charged.off",

--- a/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductOverAppliedAmountTest.java
+++ b/integration-tests/src/test/java/org/apache/fineract/integrationtests/LoanProductOverAppliedAmountTest.java
@@ -21,6 +21,7 @@ package org.apache.fineract.integrationtests;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -33,6 +34,7 @@ import org.apache.fineract.client.models.PostLoanProductsResponse;
 import org.apache.fineract.client.models.PostLoansDisbursementData;
 import org.apache.fineract.client.models.PutLoanProductsProductIdRequest;
 import org.apache.fineract.client.models.PutLoanProductsProductIdResponse;
+import org.apache.fineract.client.util.CallFailedRuntimeException;
 import org.apache.fineract.integrationtests.common.ClientHelper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanStatus;
 import org.junit.jupiter.api.Test;
@@ -147,6 +149,136 @@ public class LoanProductOverAppliedAmountTest extends BaseLoanIntegrationTest {
                     "availableDisbursementAmount should not be negative. Expected >= 0, but was: " + availableDisbursementAmount);
             assertEquals(BigDecimal.ZERO, availableDisbursementAmount,
                     "availableDisbursementAmount should be 0 when disbursed amount exceeds approved amount");
+        });
+    }
+
+    @Test
+    public void testSingleDisbursementExceedingPercentageOverAppliedMaxShouldFail() {
+        runAt("01 January 2024", () -> {
+            final PostLoanProductsRequest loanProductRequest = create4IProgressive().multiDisburseLoan(true).maxTrancheCount(5)
+                    .outstandingLoanBalance(10000.0).disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(true)
+                    .overAppliedCalculationType("percentage").overAppliedNumber(30); // max = 1000 * 1.30 = 1300
+
+            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
+            final Long loanProductId = loanProductResponse.getResourceId();
+
+            final Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            assertNotNull(clientId);
+
+            final Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 January 2024", 1000.0, 7.0, 6,
+                    request -> request.disbursementData(List.of(new PostLoansDisbursementData().expectedDisbursementDate("1 January 2024")
+                            .principal(BigDecimal.valueOf(1000.0)))));
+
+            // Disburse 1500 in one shot → exceeds max 1300 → must fail
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> disburseLoan(loanId, BigDecimal.valueOf(1500.0), "01 January 2024"));
+
+            assertTrue(
+                    exception.getMessage().contains("Loan disbursal amount can't be greater than maximum applied loan amount calculation"));
+        });
+    }
+
+    @Test
+    public void testCumulativeDisbursementsExceedingPercentageOverAppliedMaxShouldFail() {
+        runAt("01 January 2024", () -> {
+            final PostLoanProductsRequest loanProductRequest = create4IProgressive().multiDisburseLoan(true).maxTrancheCount(5)
+                    .outstandingLoanBalance(10000.0).disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(true)
+                    .overAppliedCalculationType("percentage").overAppliedNumber(50); // max = 1000 * 1.50 = 1500
+
+            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
+            final Long loanProductId = loanProductResponse.getResourceId();
+
+            final Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            assertNotNull(clientId);
+
+            final Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 January 2024", 1000.0, 7.0, 6,
+                    request -> request.disbursementData(List.of(
+                            new PostLoansDisbursementData().expectedDisbursementDate("1 January 2024").principal(BigDecimal.valueOf(500.0)),
+                            new PostLoansDisbursementData().expectedDisbursementDate("15 January 2024")
+                                    .principal(BigDecimal.valueOf(500.0)))));
+
+            // 1st disbursement: 800 (cumulative = 800, within max 1500) → OK
+            disburseLoan(loanId, BigDecimal.valueOf(800.0), "01 January 2024");
+            verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+
+            // 2nd disbursement: 800 (cumulative = 1600, exceeds max 1500) → must FAIL
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> disburseLoan(loanId, BigDecimal.valueOf(800.0), "15 January 2024"));
+
+            assertTrue(
+                    exception.getMessage().contains("Loan disbursal amount can't be greater than maximum applied loan amount calculation"));
+        });
+    }
+
+    @Test
+    public void testCumulativeDisbursementsWithinPercentageOverAppliedMaxShouldSucceed() {
+        runAt("01 January 2024", () -> {
+            final PostLoanProductsRequest loanProductRequest = create4IProgressive().multiDisburseLoan(true).maxTrancheCount(5)
+                    .outstandingLoanBalance(10000.0).disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(true)
+                    .overAppliedCalculationType("percentage").overAppliedNumber(50); // max = 1000 * 1.50 = 1500
+
+            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
+            final Long loanProductId = loanProductResponse.getResourceId();
+
+            final Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            assertNotNull(clientId);
+
+            final Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 January 2024", 1000.0, 7.0, 6,
+                    request -> request.disbursementData(List.of(
+                            new PostLoansDisbursementData().expectedDisbursementDate("1 January 2024").principal(BigDecimal.valueOf(500.0)),
+                            new PostLoansDisbursementData().expectedDisbursementDate("15 January 2024")
+                                    .principal(BigDecimal.valueOf(500.0)))));
+
+            // 1st disbursement: 800 → OK
+            disburseLoan(loanId, BigDecimal.valueOf(800.0), "01 January 2024");
+            verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+
+            // 2nd disbursement: 600 (cumulative = 1400 < max 1500) → OK
+            assertDoesNotThrow(() -> disburseLoan(loanId, BigDecimal.valueOf(600.0), "15 January 2024"));
+            verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+
+            // Verify total disbursed = 1400
+            final GetLoansLoanIdResponse loanDetails = loanTransactionHelper.getLoanDetails(loanId);
+            assertNotNull(loanDetails);
+            assertNotNull(loanDetails.getDisbursementDetails());
+
+            double totalDisbursed = loanDetails.getDisbursementDetails().stream().mapToDouble(detail -> {
+                assertNotNull(detail.getPrincipal());
+                return detail.getPrincipal();
+            }).sum();
+            assertEquals(1400.0, totalDisbursed, 0.01, "Total disbursed should be 1400 (800 + 600)");
+        });
+    }
+
+    @Test
+    public void testCumulativeDisbursementsExceedingFlatOverAppliedMaxShouldFail() {
+        runAt("01 January 2024", () -> {
+            final PostLoanProductsRequest loanProductRequest = create4IProgressive().multiDisburseLoan(true).maxTrancheCount(5)
+                    .outstandingLoanBalance(10000.0).disallowExpectedDisbursements(false).allowApprovedDisbursedAmountsOverApplied(true)
+                    .overAppliedCalculationType("flat").overAppliedNumber(200); // max = 1000 + 200 = 1200
+
+            final PostLoanProductsResponse loanProductResponse = loanProductHelper.createLoanProduct(loanProductRequest);
+            final Long loanProductId = loanProductResponse.getResourceId();
+
+            final Long clientId = clientHelper.createClient(ClientHelper.defaultClientCreationRequest()).getClientId();
+            assertNotNull(clientId);
+
+            final Long loanId = applyAndApproveProgressiveLoan(clientId, loanProductId, "1 January 2024", 1000.0, 7.0, 6,
+                    request -> request.disbursementData(List.of(
+                            new PostLoansDisbursementData().expectedDisbursementDate("1 January 2024").principal(BigDecimal.valueOf(500.0)),
+                            new PostLoansDisbursementData().expectedDisbursementDate("15 January 2024")
+                                    .principal(BigDecimal.valueOf(500.0)))));
+
+            // 1st disbursement: 700 (cumulative = 700, within max 1200) → OK
+            disburseLoan(loanId, BigDecimal.valueOf(700.0), "01 January 2024");
+            verifyLoanStatus(loanId, LoanStatus.ACTIVE);
+
+            // 2nd disbursement: 600 (cumulative = 1300, exceeds max 1200) → must FAIL
+            CallFailedRuntimeException exception = assertThrows(CallFailedRuntimeException.class,
+                    () -> disburseLoan(loanId, BigDecimal.valueOf(600.0), "15 January 2024"));
+
+            assertTrue(
+                    exception.getMessage().contains("Loan disbursal amount can't be greater than maximum applied loan amount calculation"));
         });
     }
 }


### PR DESCRIPTION

## Description

Core Logic (LoanDisbursementValidator.java): Changed 'disbursedAmount' to 'totalDisbursed' in the 'compareDisbursedToApprovedOrProposedPrincipal()' method when expected tranches are enabled ('disallowExpectedDisbursements = false') and overapplied is allowed. This ensures the cumulative total of all disbursements is validated against the max allowed amount, consistent with the behavior when 'disallowExpectedDisbursements = true'.

Pre-validation Fix (LoanTransactionValidatorImpl.java): Updated the call site in 'validateDisbursement()' to pass 'alreadyDisbursed + principal' (cumulative total including the current requested disbursement) instead of only the already disbursed total. Previously, 'getTotalPrincipalDisbursed()' was passed as `totalDisbursed', which excluded the current requested principal allowing an over-the-limit disbursement to pass pre-validation. Now both the pre-validation (LoanTransactionValidatorImpl) and post-update validation (LoanDisbursementService) paths pass a correct cumulative total.


## Changes Made

Core Logic (LoanDisbursementValidator.java): Changed `disbursedAmount` to `totalDisbursed` in the `compareDisbursedToApprovedOrProposedPrincipal()` method when expected tranches are enabled (`disallowExpectedDisbursements = false`) and overapplied is allowed. This ensures the cumulative total of all disbursements is validated against the max allowed amount, consistent with the behavior when `disallowExpectedDisbursements = true`.

Testing (LoanProductOverAppliedAmountTest.java):
Added 4 new integration test methods to cover the JIRA scenarios:
- `testSingleDisbursementExceedingPercentageOverAppliedMaxShouldFail` — single disbursement exceeding max with percentage calculation.
- `testCumulativeDisbursementsExceedingPercentageOverAppliedMaxShouldFail` — cumulative disbursements exceeding max with percentage calculation (core bug scenario).
- `testCumulativeDisbursementsWithinPercentageOverAppliedMaxShouldSucceed` — valid cumulative disbursements within max (positive case).
- `testCumulativeDisbursementsExceedingFlatOverAppliedMaxShouldFail` — cumulative disbursements exceeding max with flat calculation.
