### PR TITLE
FINERACT-2529: pass externalId instead of null resolvedClientId in Cl…

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/client/api/ClientsApiResource.java
@@ -461,7 +461,7 @@ public class ClientsApiResource {
             clientExternalId.throwExceptionIfEmpty();
             resolvedClientId = clientReadPlatformService.retrieveClientIdByExternalId(clientExternalId);
             if (resolvedClientId == null) {
-                throw new ClientNotFoundException(resolvedClientId);
+                throw new ClientNotFoundException(clientExternalId);
             }
         }
         return resolvedClientId;


### PR DESCRIPTION
## Problem
In `ClientApiResource.java`, the `getResolvedClientId` method throws a `ClientNotFoundException` using `resolvedClientId` variable. However, this block of code only executes when `resolvedClientId` is null, resulting in an unhelpful error message: "Client with identifier null does not exist."

## Fix
Passed the `externalId` string to the exception instead of `resolvedClientId`, so the error message accurately reflects which external identifier failed to resolve.