### PR TITLE
[FINERACT-2594] Fix Liquibase deletion order for client-charge permissions

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0231_remove_clientcharge_inactivate_permissions.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0231_remove_clientcharge_inactivate_permissions.xml
@@ -24,17 +24,14 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
     <changeSet author="fineract" id="1">
         <comment>Remove INACTIVATE_CLIENTCHARGE permissions - command was never implemented and the client-charge inactivate write path is being removed.</comment>
-        <delete tableName="m_role_permission">
-            <where>permission_id=(SELECT id FROM m_permission WHERE code='INACTIVATE_CLIENTCHARGE')</where>
-        </delete>
-        <delete tableName="m_role_permission">
-            <where>permission_id=(SELECT id FROM m_permission WHERE code='INACTIVATE_CLIENTCHARGE_CHECKER')</where>
-        </delete>
-        <delete tableName="m_permission">
-            <where>code='INACTIVATE_CLIENTCHARGE'</where>
-        </delete>
-        <delete tableName="m_permission">
-            <where>code='INACTIVATE_CLIENTCHARGE_CHECKER'</where>
-        </delete>
+        <sql><![CDATA[
+            DELETE FROM m_role_permission
+            WHERE permission_id IN (
+                SELECT id FROM m_permission WHERE code IN ('INACTIVATE_CLIENTCHARGE', 'INACTIVATE_CLIENTCHARGE_CHECKER')
+            );
+
+            DELETE FROM m_permission
+            WHERE code IN ('INACTIVATE_CLIENTCHARGE', 'INACTIVATE_CLIENTCHARGE_CHECKER');
+        ]]></sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Description

a short explanation of the root cause: deleting from m_permission directly hit the m_role_permission foreign key
the fix: delete the role-permission mappings first, then delete the permission rows
the validation you already ran:
XML parsed successfully
the SQL sequence was verified in PostgreSQL-compatible logic


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [x] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [x] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [x] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [x] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).
- [x] If merging this PR resolves a JIRA issue, I will mark that issue as resolved and set "Fix Version/s" appropriately.

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
